### PR TITLE
Community redirection issue

### DIFF
--- a/users/common_api.py
+++ b/users/common_api.py
@@ -419,7 +419,7 @@ def get_my_bookmarks(
                                     title=community.name,
                                     type="community",
                                     details=f"{community.member_count} members",
-                                    slug=community.slug,
+                                    slug=community.name,
                                     created_at=bookmark.created_at,
                                 )
                             )


### PR DESCRIPTION
### Redirection Bug.

#### Django automatically normalizes slugs to lowercase, this caused lookups to fail for communities with uppercase letters in their names (e.g :  'Testing_Comm' became 'testing_comm')

### Bug video :
https://github.com/user-attachments/assets/06f5400c-ed29-4b59-82bd-c82e76a9d1fc


### Fix Video : 
https://github.com/user-attachments/assets/d29eeed5-1126-4299-be0a-6456848d4d85


@bsureshkrishna Sir, Please have a look !