### PR TITLE
Pin django-ninja and add CI setup sanity checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,91 @@ on:
     - cron: '0 0 * * 1'  # Runs every Monday at midnight
 
 jobs:
+  setup-sanity:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_DB: test_db
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_password
+        options: >-
+          --health-cmd "pg_isready -U test_user"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12.3'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+        poetry install
+
+    - name: Wait for PostgreSQL to be ready
+      run: |
+        echo "Waiting for PostgreSQL to be ready..."
+        while ! pg_isready -h localhost -p 5432 -U test_user; do
+          sleep 1
+        done
+
+    - name: Run Django setup sanity checks
+      env:
+        SECRET_KEY: 'ci-secret-key'
+        DEBUG: 'True'
+        ENVIRONMENT: 'ci'
+        FRONTEND_URL: 'https://dummy-frontend.example.com'
+        EMAIL_HOST: 'smtp.example.com'
+        EMAIL_HOST_USER: 'dummy@example.com'
+        EMAIL_HOST_PASSWORD: 'dummypassword'
+        EMAIL_PORT: '587'
+        EMAIL_USE_TLS: 'True'
+        DEFAULT_FROM_EMAIL: 'noreply@example.com'
+        DB_NAME: test_db
+        DB_USER: test_user
+        DB_PASSWORD: test_password
+        DB_HOST: localhost
+        DB_PORT: 5432
+        DATABASE_URL: postgres://test_user:test_password@localhost:5432/test_db
+        AWS_ACCESS_KEY_ID: 'DUMMYACCESSKEYID'
+        AWS_SECRET_ACCESS_KEY: 'DUMMYSECRETACCESSKEY'
+        AWS_STORAGE_BUCKET_NAME: 'dummy-bucket'
+        AWS_S3_REGION_NAME: 'us-east-1'
+        CELERY_BROKER_URL: 'redis://localhost:6379/0'
+        CELERY_RESULT_BACKEND: 'redis://localhost:6379/0'
+        REDIS_HOST_URL: 'redis://localhost:6379/1'
+        REALTIME_REDIS_URL: 'redis://localhost:6379/3'
+        TORNADO_URL: 'http://localhost:8888'
+        TORNADO_PORT: '8888'
+        QUEUE_TTL_MINUTES: '2'
+        MAX_EVENTS_PER_QUEUE: '1000'
+        POLL_TIMEOUT_SECONDS: '60'
+        HEARTBEAT_INTERVAL_SECONDS: '60'
+      run: |
+        poetry run python manage.py check
+        poetry run python manage.py migrate --noinput
+
   pre-commit:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 ## Set up Guide
 
+### Compatibility Notes
+
+- This project is currently compatible with `django-ninja==1.4.1`.
+- Running with `django-ninja` 1.5+ may break startup due to `ModelSchema` API changes.
+
 ### 1. Create a Virtual Environment
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ post_install = "scripts.post_install:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 django = "^5.0.4"
-django-ninja = "^1.4.1"
+django-ninja = "1.4.1"
 python-decouple = "^3.8"
 psycopg2-binary = "^2.9.9"
 djangorestframework-simplejwt = "^5.3.1"


### PR DESCRIPTION
## What
Pin `django-ninja` to `1.4.1` and add setup sanity checks in CI.

## Why
Fresh installs can resolve `django-ninja` to `1.5.x`, but current code uses `ModelSchema Config` style compatible with `1.4.x`. This causes `manage.py migrate` failures in clean environments.

## Changes
- Pin `django-ninja` in `pyproject.toml`
- Add compatibility note in `README.md`
- Add `setup-sanity` job in CI that runs:
  - `poetry install`
  - `poetry run python manage.py check`
  - `poetry run python manage.py migrate --noinput`

## Validation
- Local `poetry run python manage.py check` passes
- Local `poetry run python manage.py migrate --noinput` passes
