### PR TITLE
feat: AI reviewer recommendation endpoint for editorial workflow 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ COPY pyproject.toml poetry.lock /app/
 RUN pip install poetry==1.7.1
 
 # Install Python dependencies from lockfile (no sync to avoid removing Poetry)
-RUN poetry config virtualenvs.create false \
+# Pre-install sentence-transformers with pip to avoid poetry hanging on massive PyTorch wheels
+RUN pip install --default-timeout=1000 sentence-transformers --extra-index-url https://download.pytorch.org/whl/cpu \
+    && poetry config virtualenvs.create false \
     && poetry install --without dev --no-root
 
 # Install Redis (necessary for Celery)

--- a/articles/management/commands/__init__.py
+++ b/articles/management/commands/__init__.py
@@ -1,1 +1,1 @@
-# Empty file to make this a Python package
+# Empty init file

--- a/articles/management/commands/seed_poc_data.py
+++ b/articles/management/commands/seed_poc_data.py
@@ -1,0 +1,89 @@
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from users.models import User
+from communities.models import Community, Membership, CommunityArticle
+from articles.models import Article
+
+class Command(BaseCommand):
+    help = 'Seeds PoC data for the AI Reviewer Recommendation system'
+
+    def handle(self, *args, **kwargs):
+        self.stdout.write("Starting PoC data seed...")
+
+        # 1. Create a Community
+        community, _ = Community.objects.get_or_create(
+            name="Cognitive Neuroscience Society",
+            defaults={"description": "Community dedicated to neuroimaging and cognition research."}
+        )
+
+        # 2. Create Users (Reviewers with different semantic bios)
+        users_data = [
+            {
+                "username": "dr_fmri_expert",
+                "email": "fmri@example.com",
+                "bio": "Neuroscientist specializing in functional magnetic resonance imaging (fMRI) to study attention, working memory, and prefrontal cortex function."
+            },
+            {
+                "username": "eeg_researcher",
+                "email": "eeg@example.com",
+                "bio": "Cognitive psychology researcher focused on temporal dynamics of attention using electroencephalography (EEG) and event-related potentials."
+            },
+            {
+                "username": "clinical_neurologist",
+                "email": "clinical@example.com",
+                "bio": "Physician treating patients with frontal lobe lesions, studying the behavioral impacts of disrupted attention networks."
+            },
+            {
+                "username": "computational_modeler",
+                "email": "comp@example.com",
+                "bio": "Computer scientist building artificial neural networks inspired by human brain architecture to simulate cognitive processes."
+            },
+            {
+                "username": "botanist_user",
+                "email": "botany@example.com",
+                "bio": "Plant biologist studying photosynthesis pathways, soil microbiomes, and environmental adaptations in tropical flora."
+            }
+        ]
+
+        memberships_created = 0
+        for data in users_data:
+            user, created = User.objects.get_or_create(
+                username=data["username"],
+                defaults={"email": data["email"], "bio": data["bio"]}
+            )
+            # Add to community
+            Membership.objects.get_or_create(
+                user=user,
+                community=community,
+                defaults={"joined_at": timezone.now()}
+            )
+            if created:
+                memberships_created += 1
+
+        # 3. Create Submitting User
+        submitter, _ = User.objects.get_or_create(
+            username="author_jones",
+            defaults={"email": "jones@test.com", "bio": "Postdoc studying human attention."}
+        )
+
+        # 4. Create the Article
+        article, _ = Article.objects.get_or_create(
+            title="Attention mechanisms in prefrontal cortex during working memory tasks",
+            defaults={
+                "abstract": "We utilized high-resolution fMRI to investigate the role of the dorsolateral prefrontal cortex in sustaining attention during a delayed-response task. Results suggest a dynamic network engagement...",
+                "submitter": submitter,
+                "submission_type": "Public"
+            }
+        )
+
+        # 5. Add Article to Community
+        CommunityArticle.objects.get_or_create(
+            article=article,
+            community=community,
+            defaults={"status": "submitted"}
+        )
+
+        self.stdout.write(self.style.SUCCESS("Seed data created successfully"))
+        self.stdout.write(f"Article ID: {article.id}")
+        self.stdout.write(f"Community ID: {community.id}")
+        self.stdout.write("Use these IDs in the editorial dashboard.")

--- a/articles/reviewer_recommendation.py
+++ b/articles/reviewer_recommendation.py
@@ -1,0 +1,100 @@
+from ninja import Router
+from django.http import HttpRequest
+from ninja.errors import HttpError
+from pydantic import BaseModel
+from sentence_transformers import SentenceTransformer, util
+from articles.models import Article
+from communities.models import Membership, Community, CommunityArticle
+from users.models import User
+
+router = Router(tags=["Editorial"])
+
+# CRITICAL: load at module level — NOT inside any function
+model = SentenceTransformer("all-MiniLM-L6-v2")
+
+
+class ReviewerSuggestion(BaseModel):
+    user_id: int
+    username: str
+    similarity_score: float
+    match_percentage: int
+
+
+class ReviewerRecommendationResponse(BaseModel):
+    article_id: int
+    article_title: str
+    community_id: int
+    article_status: str
+    suggestions: list[ReviewerSuggestion]
+
+
+@router.get("/{article_id}/suggest-reviewers", response=ReviewerRecommendationResponse)
+def suggest_reviewers(request: HttpRequest, article_id: int, community_id: int):
+    """
+    AI-Powered Reviewer Recommendation Endpoint for the GSoC 2026 PoC.
+    Returns a ranked list of best-matched reviewers from a community based on 
+    semantic similarity between the paper's title/abstract and the reviewers' profiles.
+    """
+    try:
+        article = Article.objects.get(id=article_id)
+    except Article.DoesNotExist:
+        raise HttpError(404, "Article not found")
+
+    try:
+        community = Community.objects.get(id=community_id)
+    except Community.DoesNotExist:
+        raise HttpError(404, "Community not found")
+
+    # Get CommunityArticle status
+    try:
+        ca = CommunityArticle.objects.get(article=article, community=community)
+        article_status = ca.status
+    except CommunityArticle.DoesNotExist:
+        article_status = "not_submitted"
+
+    # Fetch memberships
+    memberships = Membership.objects.filter(community=community).select_related("user")
+    if not memberships.exists():
+        return ReviewerRecommendationResponse(
+            article_id=article_id,
+            article_title=article.title,
+            community_id=community_id,
+            article_status=article_status,
+            suggestions=[],
+        )
+
+    # Build article text and calculate embedding
+    article_text = f"{article.title}. {article.abstract or ''}"
+    article_embedding = model.encode(article_text, convert_to_tensor=True)
+
+    suggestions_list = []
+    
+    # Calculate similarities with each member
+    for membership in memberships:
+        user = membership.user
+        user_text = f"{user.username} {user.bio or ''}"
+        user_embedding = model.encode(user_text, convert_to_tensor=True)
+        
+        # Calculate cosine similarity and extract float value
+        score = float(util.cos_sim(article_embedding, user_embedding)[0][0])
+        
+        suggestions_list.append(
+            ReviewerSuggestion(
+                user_id=user.id,
+                username=user.username,
+                similarity_score=round(score, 4),
+                match_percentage=round(score * 100)
+            )
+        )
+
+    # Sort descending by similarity score and get top 5
+    suggestions_list.sort(key=lambda x: x.similarity_score, reverse=True)
+    top_5 = suggestions_list[:5]
+
+    return ReviewerRecommendationResponse(
+        article_id=article_id,
+        article_title=article.title,
+        community_id=community_id,
+        article_status=article_status,
+        suggestions=top_5,
+    )

--- a/myapp/api.py
+++ b/myapp/api.py
@@ -91,6 +91,9 @@ articles_parent_router.add_router("", articles_router)
 articles_parent_router.add_router("", articles_review_router)
 articles_parent_router.add_router("", articles_discussion_router)
 
+from articles.reviewer_recommendation import router as editorial_router
+articles_parent_router.add_router("", editorial_router)
+
 # Create a parent router to aggregate all community-related endpoints
 communities_parent_router = Router()
 
@@ -107,3 +110,5 @@ api.add_router("/realtime", realtime_router)
 api.add_router("/flags", flags_router)
 api.add_router("/uploads", upload_router)
 # api.add_router("/posts", posts_router)
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ uvicorn = {extras = ["standard"], version = "^0.27.1"}
 daphne = "^4.1.0"
 channels-redis = "^4.2.0"
 tornado = "^6.4"
+sentence-transformers = {extras = ["cpu"], version = "^3.0.1"}
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.7.0"


### PR DESCRIPTION


- Adds GET /articles/{id}/suggest-reviewers endpoint using Django-Ninja
- Semantic similarity via sentence-transformers (all-MiniLM-L6-v2)
- Returns top 5 community members ranked by cosine similarity to abstract
- Includes CommunityArticle status in response
- Adds seed management command for local testing
